### PR TITLE
Properly destruct communicators.

### DIFF
--- a/lib/resources.cpp
+++ b/lib/resources.cpp
@@ -131,6 +131,14 @@ CollectiveResources* acquireCollectiveResources(
       }
     }
   }
+
+#ifdef TORCH_MPI_GLOO
+  if (gloo.with && !it->second->glooContext) {
+    it->second->glooContext =
+      makeGlooContext(it->second->comm->intraComm);
+  }
+#endif
+
   it->second->inUse = true;
   return it->second;
 }

--- a/lib/torch_mpi_cuda.cpp
+++ b/lib/torch_mpi_cuda.cpp
@@ -47,7 +47,7 @@ namespace torch { namespace mpi { namespace thc {
 
   template<typename THStoragePtrType>
   void freeRetainedStorage(THCState* state) {
-    collectiveResources().clear();
+    freeCollectiveResourcesCuda();
     auto& retained = retainedStorages<THStoragePtrType>();
     for (auto it : retained) {
       torch::thc::free(state, it.first);


### PR DESCRIPTION
1) Communicators would previously not be properly destructed
because the collectivesResources would be emptied prior to
their contents being deleted.

2) Gloo integration was broken on cpu after the resources
refactor

3) Some small improvements  around using emplace_back over
push_back with move.