### PR TITLE
Don't generate CudaByteTensor collectives

### DIFF
--- a/lib/generic/torch_collectives_wrappers.cpp.in
+++ b/lib/generic/torch_collectives_wrappers.cpp.in
@@ -9,13 +9,14 @@
 /**********************************************************************
  ********************** C Wrapper instantiations **********************
  **********************************************************************/
-#define CPP_TYPE uint8_t
-#define TH_TENSOR_TYPE THByteTensor
-#define THC_TENSOR_TYPE THCudaByteTensor
-FUNCTIONS_TO_INSTANTIATE(CPP_TYPE, TH_TENSOR_TYPE, THC_TENSOR_TYPE)
-#undef CPP_TYPE
-#undef TH_TENSOR_TYPE
-#undef THC_TENSOR_TYPE
+// TODO: nccl unsigned char does not exist
+//#define CPP_TYPE uint8_t
+//#define TH_TENSOR_TYPE THByteTensor
+//#define THC_TENSOR_TYPE THCudaByteTensor
+//FUNCTIONS_TO_INSTANTIATE(CPP_TYPE, TH_TENSOR_TYPE, THC_TENSOR_TYPE)
+//#undef CPP_TYPE
+//#undef TH_TENSOR_TYPE
+//#undef THC_TENSOR_TYPE
 
 #define CPP_TYPE char
 #define TH_TENSOR_TYPE THCharTensor


### PR DESCRIPTION
because ncclUnsignedChar doesn't exist.

Some of this code could be reworked in the future to just not
generate nccl collectives rather than all collectives.