### PR TITLE
Add support for char, int, long, double types to collectives_all test.

### DIFF
--- a/lib/torch_mpi_cuda.cpp
+++ b/lib/torch_mpi_cuda.cpp
@@ -64,6 +64,10 @@ void torch::mpi::thc::retainStorage<THCudaByteTensor>(
   THCState*,
   THCudaByteTensor* tensor);
 template
+void torch::mpi::thc::retainStorage<THCudaCharTensor>(
+  THCState*,
+  THCudaCharTensor* tensor);
+template
 void torch::mpi::thc::retainStorage<THCudaShortTensor>(
   THCState*,
   THCudaShortTensor* tensor);


### PR DESCRIPTION
Tensor type can be specified via -type parameter.  Float is the default,
as before, and 'all' (iterate over above types) is supported.

Also, allow specifying uppersizepow for the largest size of a tensor
(i.e. 2^uppersizepow is the largest tensor used in the test).  This is
used since on an M40 I'm getting OOM issues with every parameter set
to all.